### PR TITLE
refactor(lib/Utils/StringHelpers): Remove unused strstartswith function

### DIFF
--- a/lib/Utils/StringHelpers.php
+++ b/lib/Utils/StringHelpers.php
@@ -22,9 +22,4 @@ class StringHelpers {
     );
     return join($a, ' ');
   }
-
-  public static function strstartswith($haystack, $needle) {
-    if (!$needle) return false;
-    return strpos($haystack, $needle) === 0;
-  }
 }


### PR DESCRIPTION
Was previously used in the Navigation datastore in the old stack, but we don't have this anymore, so this isn't actually used anywhere.

https://github.com/bleech/bleech-wp-starter/blob/b489bb0dc1853c5b08c5b09acea925cc7de2d925/src/App/DataStores/Navigation.php#L49

Should we then just remove it?