### PR TITLE
Features/Navigation: Change hook to init

### DIFF
--- a/Features/Navigation/functions.php
+++ b/Features/Navigation/functions.php
@@ -2,9 +2,9 @@
 
 namespace Flynt\Features\Navigation;
 
-add_action('after_setup_theme', function () {
-  register_nav_menus(array(
+add_action('init', function () {
+  register_nav_menus([
     'main_navigation' => __('Main Navigation', 'flynt-theme'),
     'footer_navigation' => __('Footer Navigation', 'flynt-theme')
-  ));
+  ]);
 });


### PR DESCRIPTION
This somehow fixes the menu sub-page showing up. Not sure why it doesn't work with
after_setup_theme.

resolves #59