### PR TITLE
Features/CustomPostType: Invalid json files

### DIFF
--- a/Features/CustomPostTypes/CustomPostTypeRegister.php
+++ b/Features/CustomPostTypes/CustomPostTypeRegister.php
@@ -120,7 +120,10 @@ class CustomPostTypeRegister
                     self::$registeredCustomPostTypes[$name] = [
                         'dir' => $dir
                     ];
-                    return array_merge(self::getConfigFromJson($configPath), ['name' => $name]);
+                    $config = self::getConfigFromJson($configPath);
+                    if (!empty($config)) {
+                        return array_merge($config, ['name' => $name]);
+                    }
                 }
             }
             return null;


### PR DESCRIPTION
Slightly improved version of #93 

- new PR since PHP code style has changed to PSR-2
- show error message (Warning) directly after decoding the file
- no need to keep the invalid configs in the array since the error message already has enough information

resolves #122