### PR TITLE
fix(Features/Acf/Loader): Fix 'could not initialise helpers' notice

### DIFF
--- a/Features/Acf/Loader.php
+++ b/Features/Acf/Loader.php
@@ -103,10 +103,10 @@ class Loader
 
         $manager = AdminNoticeManager::getInstance();
         $manager->addNotice($messages, [
-        'title' => 'Could not initialize ACF Helpers (' . implode(', ', self::$helpers) . ')',
-        'type' => 'warning',
-        'dismissible' => true,
-        'filenames' => basename(__DIR__)
+            'title' => 'Could not initialize ACF Helpers (' . implode(', ', array_keys(self::$helpers)) . ')',
+            'type' => 'warning',
+            'dismissible' => true,
+            'filenames' => basename(__DIR__)
         ]);
     }
 }


### PR DESCRIPTION
It was not outputting names of helpers, but only outputting `(Array, Array, Array, Array)` before