### PR TITLE
fix(Components/BlockMediaText/fields.json): Added a tabEnd field

### DIFF
--- a/Components/BlockMediaText/fields.json
+++ b/Components/BlockMediaText/fields.json
@@ -19,7 +19,7 @@
         "default_value": ""
       },
       {
-        "name": "image2",
+        "name": "image",
         "label": "Image",
         "type": "image",
         "mime_types": "jpg,jpeg",
@@ -68,7 +68,7 @@
         ]
       },
       {
-        "name": "contentHTML2",
+        "name": "contentHTML",
         "label": "Content",
         "type": "wysiwyg",
         "media_upload": 0,


### PR DESCRIPTION
Added a tabEnd field after the last tab element, with an empty label and endpoint defined, to
prevent next component fields from showing up in the last tab.