### PR TITLE
fix(Features/AdminComponentPreview/auth): Changed getComponentImages element

### DIFF
--- a/Features/AdminComponentPreview/auth.js
+++ b/Features/AdminComponentPreview/auth.js
@@ -33,7 +33,7 @@ function hideImages () {
 }
 
 function getComponentImages (output = {}) {
-  $('.pageWrapper [is]').each(function () {
+  $('.pageWrapper [is^="flynt-"]').each(function () {
     const componentString = $(this).attr('is')
     let componentName = $.camelCase(componentString.substring(componentString.indexOf('-') + 1))
     componentName = helper.firstToUpperCase(componentName)


### PR DESCRIPTION
Changed the getComponentsImages element from mainContent to pageWrapper, to also get the components images outside of the mainContent (header, footer...)