### PR TITLE
Features/Jquery: add local fallback to jquery feature

### DIFF
--- a/Components/BlockMediaText/script.js
+++ b/Components/BlockMediaText/script.js
@@ -1,3 +1,5 @@
+import $ from 'jquery'
+
 class BlockMediaText extends window.HTMLDivElement {
   constructor (self) {
     self = super(self)

--- a/Components/BlockVideoOembed/script.js
+++ b/Components/BlockVideoOembed/script.js
@@ -1,3 +1,5 @@
+import $ from 'jquery'
+
 class BlockVideoOembed extends window.HTMLDivElement {
   constructor (self) {
     self = super(self)

--- a/Components/SliderMedia/script.js
+++ b/Components/SliderMedia/script.js
@@ -1,3 +1,4 @@
+import $ from 'jquery'
 import 'file-loader?name=vendor/slick.js!slick-carousel/slick/slick.min'
 import 'file-loader?name=vendor/slick.css!csso-loader!slick-carousel/slick/slick.css'
 

--- a/Features/AdminComponentPreview/auth.js
+++ b/Features/AdminComponentPreview/auth.js
@@ -1,4 +1,5 @@
 /* globals wpData */
+import $ from 'jquery'
 const helper = require('./helper')
 const $body = $('body')
 let $container = null

--- a/Features/Jquery/README.md
+++ b/Features/Jquery/README.md
@@ -1,3 +1,3 @@
 # jQuery (Flynt Feature)
 
-Remove the Wordpress default jQuery script and loads jQuery from a CDN instead.
+Remove the Wordpress default jQuery script and load it from Google's CDN with a local fallback.

--- a/Features/Jquery/README.md
+++ b/Features/Jquery/README.md
@@ -1,3 +1,3 @@
 # jQuery (Flynt Feature)
 
-Remove the Wordpress default jQuery script and load it from Google's CDN with a local fallback.
+Loads jQuery from Google's CDN falling back to the default WordPress script.

--- a/Features/Jquery/README.md
+++ b/Features/Jquery/README.md
@@ -1,3 +1,5 @@
 # jQuery (Flynt Feature)
 
-Loads jQuery from Google's CDN falling back to the default WordPress script.
+Loads jQuery before the closing body tag by default. Can be overwritten if there is a script in the head with jQuery as a dependency.
+
+If the Asset utility has `loadFromCdn` set to true, it will load from Google's CDN falling back to the default WordPress script. This setting can be changed in the `lib/Init.php` file inside the `initTheme` function.

--- a/Features/Jquery/functions.php
+++ b/Features/Jquery/functions.php
@@ -6,7 +6,8 @@ use Flynt\Utils\Asset;
 
 add_action('wp_enqueue_scripts', function () {
     $jqueryVersion = wp_scripts()->registered['jquery']->ver;
+    $jqueryLocalUrl = esc_url(includes_url("/js/jquery/jquery.js?ver=${jqueryVersion}"));
     wp_deregister_script('jquery');
-    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/' . $jqueryVersion . '/jquery.min.js', false, $jqueryVersion, true);
-    wp_add_inline_script('jquery', 'window.jQuery||document.write("<script src=\"' . esc_url(Asset::requireUrl('vendor/jquery.min.js')) . '\"><\/script>")');
+    wp_register_script('jquery', "//ajax.googleapis.com/ajax/libs/jquery/${jqueryVersion}/jquery.min.js", false, $jqueryVersion, true);
+    wp_add_inline_script('jquery', "window.jQuery||document.write(\"<script src=\\\"${jqueryLocalUrl}\\\"><\/script>\")");
 });

--- a/Features/Jquery/functions.php
+++ b/Features/Jquery/functions.php
@@ -2,22 +2,11 @@
 
 namespace Flynt\Features\Jquery;
 
-/**
- * registerJquery
- *
- * Load jQuery from jQuery's CDN
- *
- * TODO add local fallback
- * TODO add cdn again just removed it because internet so slow
- */
+use Flynt\Utils\Asset;
+
 add_action('wp_enqueue_scripts', function () {
     $jqueryVersion = wp_scripts()->registered['jquery']->ver;
     wp_deregister_script('jquery');
-    wp_register_script(
-        'jquery',
-        '//code.jquery.com/jquery-' . $jqueryVersion . '.min.js',
-        [],
-        null,
-        true
-    );
-}, 100);
+    wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/' . $jqueryVersion . '/jquery.min.js', false, $jqueryVersion, true);
+    wp_add_inline_script('jquery', 'window.jQuery||document.write("<script src=\"' . esc_url(Asset::requireUrl('vendor/jquery.min.js')) . '\"><\/script>")');
+});

--- a/Features/Jquery/functions.php
+++ b/Features/Jquery/functions.php
@@ -3,11 +3,20 @@
 namespace Flynt\Features\Jquery;
 
 use Flynt\Utils\Asset;
+use Flynt\Utils\Feature;
 
 add_action('wp_enqueue_scripts', function () {
+    $options = Feature::getOption('flynt-jquery', 0);
     $jqueryVersion = wp_scripts()->registered['jquery']->ver;
-    $jqueryLocalUrl = esc_url(includes_url("/js/jquery/jquery.js?ver=${jqueryVersion}"));
     wp_deregister_script('jquery');
-    wp_register_script('jquery', "//ajax.googleapis.com/ajax/libs/jquery/${jqueryVersion}/jquery.min.js", false, $jqueryVersion, true);
-    wp_add_inline_script('jquery', "window.jQuery||document.write(\"<script src=\\\"${jqueryLocalUrl}\\\"><\/script>\")");
+    if (isset($options['cdn']) && true === $options['cdn']) {
+        // load jQuery from Google CDN, falling back to local WordPress-bundled file
+        $jqueryLocalUrl = esc_url(includes_url("/js/jquery/jquery.js?ver=${jqueryVersion}"));
+        wp_register_script('jquery', "//ajax.googleapis.com/ajax/libs/jquery/${jqueryVersion}/jquery.min.js", false, null, true);
+        wp_add_inline_script('jquery', "window.jQuery||document.write(\"<script src=\\\"${jqueryLocalUrl}\\\"><\/script>\")");
+    } else {
+        // make sure jQuery loads in footer by default
+        $jqueryLocalUrl = includes_url('/js/jquery/jquery.js');
+        wp_register_script('jquery', $jqueryLocalUrl, false, $jqueryVersion, true);
+    }
 });

--- a/Features/Jquery/functions.php
+++ b/Features/Jquery/functions.php
@@ -6,17 +6,17 @@ use Flynt\Utils\Asset;
 use Flynt\Utils\Feature;
 
 add_action('wp_enqueue_scripts', function () {
-    $options = Feature::getOption('flynt-jquery', 0);
     $jqueryVersion = wp_scripts()->registered['jquery']->ver;
     wp_deregister_script('jquery');
-    if (isset($options['cdn']) && true === $options['cdn']) {
-        // load jQuery from Google CDN, falling back to local WordPress-bundled file
-        $jqueryLocalUrl = esc_url(includes_url("/js/jquery/jquery.js?ver=${jqueryVersion}"));
-        wp_register_script('jquery', "//ajax.googleapis.com/ajax/libs/jquery/${jqueryVersion}/jquery.min.js", false, null, true);
-        wp_add_inline_script('jquery', "window.jQuery||document.write(\"<script src=\\\"${jqueryLocalUrl}\\\"><\/script>\")");
-    } else {
-        // make sure jQuery loads in footer by default
-        $jqueryLocalUrl = includes_url('/js/jquery/jquery.js');
-        wp_register_script('jquery', $jqueryLocalUrl, false, $jqueryVersion, true);
-    }
+
+    $jqueryLocalUrl = esc_url(includes_url("/js/jquery/jquery.js?ver=${jqueryVersion}"));
+    Asset::register([
+        'name' => 'jquery',
+        'cdn' => [
+            'url' => "//ajax.googleapis.com/ajax/libs/jquery/${jqueryVersion}/jquery.min.js",
+            'check' => 'window.jQuery'
+        ],
+        'type' => 'script',
+        'path' => $jqueryLocalUrl
+    ]);
 });

--- a/Features/Jquery/functions.php
+++ b/Features/Jquery/functions.php
@@ -19,4 +19,4 @@ add_action('wp_enqueue_scripts', function () {
         'type' => 'script',
         'path' => $jqueryLocalUrl
     ]);
-});
+}, 0); // NOTE: prio needs to be < 1

--- a/Features/Jquery/script.js
+++ b/Features/Jquery/script.js
@@ -1,1 +1,0 @@
-import 'file-loader?name=vendor/jquery.min.js!jquery/dist/jquery.min'

--- a/Features/Jquery/script.js
+++ b/Features/Jquery/script.js
@@ -1,0 +1,1 @@
+import 'file-loader?name=vendor/jquery.min.js!jquery/dist/jquery.min'

--- a/gulpfile.js/webpack.config.js
+++ b/gulpfile.js/webpack.config.js
@@ -56,7 +56,10 @@ module.exports = function (config) {
       new webpack.LoaderOptionsPlugin({
         debug: !config.production
       })
-    ]
+    ],
+    externals: {
+      jquery: 'jQuery'
+    }
   }
   if (config.production) {
     output.plugins = output.plugins || []

--- a/lib/Init.php
+++ b/lib/Init.php
@@ -5,6 +5,7 @@ namespace Flynt\Init;
 require_once __DIR__ . '/Utils/FileLoader.php';
 
 use Flynt;
+use Flynt\Utils\Asset;
 use Flynt\Utils\Feature;
 use Flynt\Utils\FileLoader;
 use Flynt\Utils\StringHelpers;
@@ -15,6 +16,9 @@ function initTheme()
 {
     // initialize plugin defaults
     Flynt\initDefaults();
+
+    // Set to true to load all assets from a CDN if there is one specified
+    Asset::loadFromCdn(false);
 
     // register all components in 'Components' folder
     add_theme_support('flynt-components', get_template_directory() . '/dist/Components/');
@@ -56,9 +60,7 @@ function initTheme()
     add_theme_support('flynt-tiny-mce');
 
     // load jQuery in footer by default (+ option to load from cdn with local fallback)
-    add_theme_support('flynt-jquery', [
-        'cdn' => true
-    ]);
+    add_theme_support('flynt-jquery');
 
     // add components previews
     add_theme_support('flynt-admin-component-preview');

--- a/lib/Init.php
+++ b/lib/Init.php
@@ -51,6 +51,9 @@ function initTheme()
     // use timber rendering
     add_theme_support('flynt-timber-loader');
 
+    // load jQuery in footer by default
+    add_theme_support('flynt-jquery');
+
     // clean up some things
     add_theme_support('flynt-clean-head');
     add_theme_support('flynt-clean-rss');
@@ -58,9 +61,6 @@ function initTheme()
     add_theme_support('flynt-navigation');
     add_theme_support('flynt-remove-editor');
     add_theme_support('flynt-tiny-mce');
-
-    // load jQuery in footer by default (+ option to load from cdn with local fallback)
-    add_theme_support('flynt-jquery');
 
     // add components previews
     add_theme_support('flynt-admin-component-preview');

--- a/lib/Init.php
+++ b/lib/Init.php
@@ -50,11 +50,15 @@ function initTheme()
     // clean up some things
     add_theme_support('flynt-clean-head');
     add_theme_support('flynt-clean-rss');
-    add_theme_support('flynt-jquery');
     add_theme_support('flynt-mime-types');
     add_theme_support('flynt-navigation');
     add_theme_support('flynt-remove-editor');
     add_theme_support('flynt-tiny-mce');
+
+    // load jQuery in footer by default (+ option to load from cdn with local fallback)
+    add_theme_support('flynt-jquery', [
+        'cdn' => true
+    ]);
 
     // add components previews
     add_theme_support('flynt-admin-component-preview');

--- a/lib/Utils/Asset.php
+++ b/lib/Utils/Asset.php
@@ -102,7 +102,6 @@ class Asset
             if (!wp_script_is($options['name'], 'registered')
                 && !wp_script_is($options['name'], 'enqueued')
             ) {
-                $cdnCheck = $options['cdn']['check'];
                 $localPath = $path;
                 $path = $options['cdn']['url'];
             } else {
@@ -113,7 +112,6 @@ class Asset
                 // deregister script and set cdn options to re-register down below
                 if ($options['cdn']['url'] !== $scriptPath) {
                     wp_deregister_script($options['name']);
-                    $cdnCheck = $options['cdn']['check'];
                     $localPath = $path;
                     $path = $options['cdn']['url'];
                 }
@@ -130,6 +128,7 @@ class Asset
             );
 
             if (isset($localPath)) {
+                $cdnCheck = $options['cdn']['check'];
                 wp_add_inline_script(
                     $options['name'],
                     "${cdnCheck}||document.write(\"<script src=\\\"${localPath}\\\"><\/script>\")"

--- a/lib/Utils/Asset.php
+++ b/lib/Utils/Asset.php
@@ -92,11 +92,13 @@ class Asset
             $path = Asset::requireUrl($path);
         }
 
-        // TODO: What if a script is registered twice?
-        if (true === self::$loadFromCdn
+        if ('script' === $options['type']
+            && true === self::$loadFromCdn
             && !empty($options['cdn'])
             && !empty($options['cdn']['check'])
             && !empty($options['cdn']['url'])
+            && !wp_script_is($options['name'], 'registered')
+            && !wp_script_is($options['name'], 'enqueued')
         ) {
             $cdnCheck = $options['cdn']['check'];
             $localPath = $path;

--- a/lib/Utils/Asset.php
+++ b/lib/Utils/Asset.php
@@ -3,6 +3,7 @@
 namespace Flynt\Utils;
 
 // TODO: add async & defer (see https://matthewhorne.me/defer-async-wordpress-scripts/); also add to cdn fallback
+// BUG: When there are several scripts registered, some with a CDN, some without, the CDN setting is only applied if it was set in the first instance.
 
 class Asset
 {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-watch": "^4.3.10",
     "hasbin": "^1.2.3",
     "jeet": "^7.0.0",
-    "jquery": "^3.2.1",
+    "jquery": "1.12.4",
     "normalize.css": "^6.0.0",
     "picturefill": "^3.0.2",
     "require-dir": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "gulp-watch": "^4.3.10",
     "hasbin": "^1.2.3",
     "jeet": "^7.0.0",
-    "jquery": "1.12.4",
     "normalize.css": "^6.0.0",
     "picturefill": "^3.0.2",
     "require-dir": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,10 +3198,6 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
-
 jquery@>=1.7.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,7 +3198,11 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@>=1.7.2, jquery@^3.2.1:
+jquery@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+
+jquery@>=1.7.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 


### PR DESCRIPTION
I'm still not 100% sure about using a CDN for this, but I was made aware that in case we don't want this in a project, it is easily removed from the `lib/Init.php`. Therefore, with the local fallback added, this shouldn't be much of an issue anymore.

When using this feature, we need to make sure to update the jQuery version in the package.json
whenever WordPress decides to bump the version. There are arguments for using a newer jQuery version than the WordPress default. However, I wouldn't do that here since it might break external plugin functionality, which we cannot test for. It is easily changed in this feature, if such a thing is necessary in the future. (Or we could add a feature parameter to specify an optional version to use.)

closes #131 