### PR TITLE
Components/DocumentDefault remove duplicate class attribute on html element

### DIFF
--- a/Components/DocumentDefault/index.twig
+++ b/Components/DocumentDefault/index.twig
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html class="no-js {{ body_class }}" lang="{{ site.language }}" dir="{{ dir }}" is="flynt-document-default" class="flyntComponent">
+<html class="flyntComponent {{ body_class }}" lang="{{ site.language }}" dir="{{ dir }}" is="flynt-document-default">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
-    <link href="{{ faviconPath|e('esc_url') }}" rel="shortcut icon" type="image/png">
-    <link rel="apple-touch-icon" href="{{ appleTouchIcon180x180Path|e('esc_url') }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ feedTitle }}" href="{{ site.rss2|e('esc_url') }}">
+    <link href="{{ faviconPath | e('esc_url') }}" rel="shortcut icon" type="image/png">
+    <link rel="apple-touch-icon" href="{{ appleTouchIcon180x180Path | e('esc_url') }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ feedTitle }}" href="{{ site.rss2 | e('esc_url') }}">
     {{ wp_head }}
   </head>
   <body role="document">


### PR DESCRIPTION
use single attribute and remove no-js class, add space for twig filters to be more consistent