### PR TITLE
lib/Bootstrap: Require ACF plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,9 +12,9 @@ use Flynt\Bootstrap;
 //          defined here.
 Bootstrap::setTemplateDirectory();
 
-// Check if the plugin is installed and activated.
-// If it isn't, this function redirects the template rendering to use
-// plugin-inactive.php instead
-if (Bootstrap::checkPlugin()) {
+// Check if the required plugins are installed and activated.
+// If they aren't, this function redirects the template rendering to use
+// plugin-inactive.php instead and shows a warning in the admin backend.
+if (Bootstrap::checkRequiredPlugins()) {
     require_once get_template_directory() . '/lib/Init.php';
 }

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -19,7 +19,7 @@ class Bootstrap
         });
     }
 
-    public static function checkPlugin()
+    public static function checkRequiredPlugins()
     {
         $flyntCoreActive = class_exists('\\Flynt\\Render');
         $acfActive = class_exists('acf');

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -21,27 +21,36 @@ class Bootstrap
 
     public static function checkPlugin()
     {
-        $pluginActive = class_exists('\\Flynt\\Render');
+        $flyntCoreActive = class_exists('\\Flynt\\Render');
+        $acfActive = class_exists('acf');
 
-        if (!$pluginActive) {
+        if (!$flyntCoreActive) {
             add_action('admin_notices', function () {
-                echo '<div class="error"><p>Flynt Core Plugin not activated. Make sure you activate the plugin in <a href="'
-                    . esc_url(admin_url('plugins.php#flynt')) . '">'
-                    . esc_url(admin_url('plugins.php')) . '</a></p></div>';
+                echo '<div class="error"><p>Flynt Core Plugin not activated. Make sure you activate the plugin on the <a href="'
+                    . esc_url(admin_url('plugins.php')) . '">plugin page</a>.</p></div>';
             });
+        }
 
+        if (!$acfActive) {
+            add_action('admin_notices', function () {
+                echo '<div class="error"><p>ACF Plugin not activated. Make sure you activate the plugin on the <a href="'
+                    . esc_url(admin_url('plugins.php')) . '">plugin page</a>.</p></div>';
+            });
+        }
+
+        if (!$acfActive || !$flyntCoreActive) {
             add_filter('template_include', function () {
-                $newTemplate = locate_template(['plugin-inactive.php']);
+                $newTemplate = locate_template('plugin-inactive.php');
                 if ('' != $newTemplate) {
                     return $newTemplate;
                 } else {
-                    return 'Flynt Core Plugin not activated! Please <a href="'
+                    return 'One or more required Plugins are not active! Please <a href="'
                         . esc_url(admin_url('plugins.php'))
-                        . '">activate the plugin</a> and reload the page.';
+                        . '">activate all required plugins</a> and reload the page.';
                 }
             });
         }
 
-        return $pluginActive;
+        return $acfActive && $flyntCoreActive;
     }
 }

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -44,9 +44,12 @@ class Bootstrap
                 if ('' != $newTemplate) {
                     return $newTemplate;
                 } else {
-                    return 'One or more required Plugins are not active! Please <a href="'
+                    trigger_error(
+                        'One or more required plugins are not activated! Please <a href="'
                         . esc_url(admin_url('plugins.php'))
-                        . '">activate all required plugins</a> and reload the page.';
+                        . '">activate or install the required plugin(s)</a> and reload the page.',
+                        E_USER_WARNING
+                    );
                 }
             });
         }

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -51,7 +51,8 @@ class Bootstrap
         return $acfActive && $flyntCoreActive;
     }
 
-    protected static function notifyRequiredPluginIsMissing($pluginName) {
+    protected static function notifyRequiredPluginIsMissing($pluginName)
+    {
         add_action('admin_notices', function () {
             echo "<div class=\"error\"><p>${pluginName} Plugin not activated. Make sure you activate the plugin on the <a href=\""
                 . esc_url(admin_url('plugins.php')) . "\">plugin page</a>.</p></div>";

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -53,7 +53,7 @@ class Bootstrap
 
     protected static function notifyRequiredPluginIsMissing($pluginName)
     {
-        add_action('admin_notices', function () {
+        add_action('admin_notices', function () use ($pluginName) {
             echo "<div class=\"error\"><p>${pluginName} Plugin not activated. Make sure you activate the plugin on the <a href=\""
                 . esc_url(admin_url('plugins.php')) . "\">plugin page</a>.</p></div>";
         });

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -25,17 +25,11 @@ class Bootstrap
         $acfActive = class_exists('acf');
 
         if (!$flyntCoreActive) {
-            add_action('admin_notices', function () {
-                echo '<div class="error"><p>Flynt Core Plugin not activated. Make sure you activate the plugin on the <a href="'
-                    . esc_url(admin_url('plugins.php')) . '">plugin page</a>.</p></div>';
-            });
+            self::notifyRequiredPluginIsMissing('Flynt Core');
         }
 
         if (!$acfActive) {
-            add_action('admin_notices', function () {
-                echo '<div class="error"><p>ACF Plugin not activated. Make sure you activate the plugin on the <a href="'
-                    . esc_url(admin_url('plugins.php')) . '">plugin page</a>.</p></div>';
-            });
+            self::notifyRequiredPluginIsMissing('ACF');
         }
 
         if (!$acfActive || !$flyntCoreActive) {
@@ -55,5 +49,12 @@ class Bootstrap
         }
 
         return $acfActive && $flyntCoreActive;
+    }
+
+    protected static function notifyRequiredPluginIsMissing($pluginName) {
+        add_action('admin_notices', function () {
+            echo "<div class=\"error\"><p>${pluginName} Plugin not activated. Make sure you activate the plugin on the <a href=\""
+                . esc_url(admin_url('plugins.php')) . "\">plugin page</a>.</p></div>";
+        });
     }
 }

--- a/templates/plugin-inactive.php
+++ b/templates/plugin-inactive.php
@@ -2,11 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Plugin Inactive!</title>
+    <title>Flynt - Plugin(s) Inactive!</title>
     <?php wp_head(); ?>
   </head>
   <body>
-    One or more required Plugins are not activated! Please
+    One or more required plugins are not activated! Please
     <a href="<?php echo admin_url('plugins.php') ?>">activate or install the required plugin(s)</a>
     and reload the page.
     <?php wp_footer(); ?>

--- a/templates/plugin-inactive.php
+++ b/templates/plugin-inactive.php
@@ -7,7 +7,7 @@
   </head>
   <body>
     One or more required Plugins are not activated! Please
-    <a href="<?= admin_url('plugins.php') ?>">activate or install the required plugin(s)</a>
+    <a href="<?php echo admin_url('plugins.php') ?>">activate or install the required plugin(s)</a>
     and reload the page.
     <?php wp_footer(); ?>
   </body>


### PR DESCRIPTION
Require ACF plugin as decided in #139 

Includes some refactoring in Bootstrap file.