### PR TITLE
ci(travis): use phpcs version < 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - yarn
 
 install:
-  - composer global require "squizlabs/php_codesniffer=*"
+  - composer global require "squizlabs/php_codesniffer=~2.9"
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - nvm install 6
   - nvm use 6


### PR DESCRIPTION
gulp-phpcs is currently not compatible with version 3.0; this is fixed in
https://github.com/JustBlackBird/gulp-phpcs/pull/35. Will revisit this issue when that package is
updated.