### PR TITLE
refactor(Components/BlockMediaText/howto): Added a notice in howto.md file

### DIFF
--- a/Components/BlockMediaText/howto.md
+++ b/Components/BlockMediaText/howto.md
@@ -26,3 +26,16 @@ add_filter('Flynt/addComponentData?name=BlockMediaText', function ($data) {
     }
 });
 ```
+
+**Beware:** If you use this component as a static component (or any component with tabs), you need to add a closing tab*, otherwise the next components will show up inside the last tab.
+
+*A tab with an empty label, and `"endpoint": 1`
+
+```json
+{
+  "name": "endTab",
+  "label": "",
+  "type": "tab",
+  "endpoint": 1
+}
+```


### PR DESCRIPTION
Added a notice in howto.md about how to add a closing tab in case of use of the component as a
static component, to avoid other components from showing up inside the last tab