### PR TITLE
Slider media fixes

### DIFF
--- a/Components/SliderMedia/Partials/SlideTitle/index.twig
+++ b/Components/SliderMedia/Partials/SlideTitle/index.twig
@@ -1,5 +1,7 @@
-<div class="slideTitle slideTitle--overlayTitleTop">
-  <div class="slideTitle-content">
-    {{ mediaSlide.titleText }}
+{% if mediaSlide.titleText %}
+  <div class="slideTitle slideTitle--overlayTitleTop">
+    <div class="slideTitle-content">
+      {{ mediaSlide.titleText }}
+    </div>
   </div>
-</div>
+{% endif %}

--- a/Components/SliderMedia/fields.json
+++ b/Components/SliderMedia/fields.json
@@ -1,11 +1,4 @@
 {
-  "translatableOptions": [
-    {
-      "name": "defaultTitleText",
-      "label": "Default Title Text",
-      "type": "text"
-    }
-  ],
   "layout": {
     "name": "sliderMedia",
     "label": "Slider: Media",

--- a/Components/SliderMedia/fields.json
+++ b/Components/SliderMedia/fields.json
@@ -1,18 +1,4 @@
 {
-  "globalOptions": [
-    {
-      "label": "Default Image",
-      "name": "defaultImage",
-      "type": "image",
-      "return_format": "array",
-      "preview_size": "thumbnail",
-      "library": "all",
-      "min_width": 1440,
-      "min_height": 720,
-      "instructions": "Recommended Size: Min-Width 1440px; Min-Height: 720px; Image-Format: JPG",
-      "mime_types": "jpg,jpeg"
-    }
-  ],
   "translatableOptions": [
     {
       "name": "defaultTitleText",
@@ -97,6 +83,7 @@
             "min_height": 720,
             "instructions": "Recommended Size: Min-Width 1440px; Min-Height: 720px; Image-Format: JPG",
             "mime_types": "jpg,jpeg",
+            "required": 1,
             "conditional_logic": [
               [
                 {

--- a/Components/SliderMedia/fields.json
+++ b/Components/SliderMedia/fields.json
@@ -30,6 +30,7 @@
         "type": "repeater",
         "layout": "row",
         "button_label": "Add Slide",
+        "min": 1,
         "sub_fields": [
           {
             "label": "Media Type",
@@ -42,6 +43,7 @@
             "default_value": "image",
             "allow_null": 0,
             "multiple": 0,
+            "required": 1,
             "ui": 1,
             "ajax": 0
           },
@@ -55,7 +57,17 @@
             "min_width": 1440,
             "min_height": 720,
             "instructions": "Recommended Size: Min-Width 1440px; Min-Height: 720px; Image-Format: JPG",
-            "mime_types": "jpg,jpeg"
+            "mime_types": "jpg,jpeg",
+            "required": 1,
+            "conditional_logic": [
+              [
+                {
+                  "fieldPath": "mediaType",
+                  "operator": "==",
+                  "value": "image"
+                }
+              ]
+            ]
           },
           {
             "label": "Oembed",
@@ -63,6 +75,28 @@
             "type": "oembed",
             "width": 100,
             "height": 100,
+            "required": 1,
+            "conditional_logic": [
+              [
+                {
+                  "fieldPath": "mediaType",
+                  "operator": "==",
+                  "value": "oembed"
+                }
+              ]
+            ]
+          },
+          {
+            "name": "posterImage",
+            "label": "Poster Image",
+            "type": "image",
+            "return_format": "array",
+            "preview_size": "thumbnail",
+            "library": "all",
+            "min_width": 1440,
+            "min_height": 720,
+            "instructions": "Recommended Size: Min-Width 1440px; Min-Height: 720px; Image-Format: JPG",
+            "mime_types": "jpg,jpeg",
             "conditional_logic": [
               [
                 {

--- a/Components/SliderMedia/functions.php
+++ b/Components/SliderMedia/functions.php
@@ -8,6 +8,7 @@ use Flynt\Utils\Oembed;
 add_filter('Flynt/addComponentData?name=SliderMedia', function ($data) {
     $data['mediaSlides'] = array_map(function ($item) {
         if ($item['mediaType'] == 'oembed') {
+            $item['image'] = $item['posterImage'];
             $item['oembedLazyLoad'] = Oembed::setSrcAsDataAttribute(
                 $item['oembed'],
                 [

--- a/Components/SliderMedia/howto.md
+++ b/Components/SliderMedia/howto.md
@@ -1,0 +1,42 @@
+# Developer HowTo´s
+
+## Global Default Poster Image for Video Oembed
+
+`fields.json`
+```json
+{
+  "globalOptions": [
+    {
+      "name": "defaultPosterImage",
+      "label": "Default Poster Image",
+      "type": "image",
+      "return_format": "array",
+      "preview_size": "thumbnail",
+      "min_width": 1440,
+      "min_height": 720,
+      "mime_types": "jpg,jpeg",
+      "instructions": "Recommended Size: Min-Width 1440px; Min-Height: 720px; Image-Format: JPG"
+    }
+  ]
+}
+```
+
+`functions.php`
+```php
+<?php
+add_filter('Flynt/addComponentData?name=SliderMedia', function ($data) {
+    if ($data['mediaType'] === 'mediaVideo' && empty($data['posterImage'])) {
+        $data['posterImage'] = $data['defaultPosterImage'];
+    }
+    $data['mediaSlides'] = array_map(function ($item) {
+        if ($item['mediaType'] == 'oembed') {
+            if (empty($item['posterImage'])) {
+                $item['image'] = $item['defaultPosterImage'];
+            } else {
+                $item['image'] = $item['posterImage'];
+            }
+        }
+        return $item;
+    }, $data['mediaSlides']);
+});
+```

--- a/Components/SliderMedia/script.js
+++ b/Components/SliderMedia/script.js
@@ -38,6 +38,8 @@ class SliderMedia extends window.HTMLDivElement {
       this.$.on('init', this.$mediaSlides.selector, this.slickInit)
       this.$mediaSlides.slick(slickConfiguration)
       this.$.on('beforeChange', this.$mediaSlides.selector, this.unsetIframeSrc)
+    } else {
+      this.$sliderMedia.removeClass('sliderMedia-isHidden')
     }
   }
 


### PR DESCRIPTION
Fixed the opacity problem if only one slide : images were not showing up.
Not showing the blank title box if no title.
Refactored fields: removed the default image (which was meant for a default poster image for videos) and default title text that were not used and unnecessary for a base component.
Added a howto.md file.