### PR TITLE
docs(lib/Utils): fix version numbers

### DIFF
--- a/lib/Utils/Asset.php
+++ b/lib/Utils/Asset.php
@@ -82,7 +82,7 @@ class Asset
      * It can enqueue a script or a style.
      *
      * @since 0.1.0
-     * @since %%NEXT_VERSION%% Supports CDN parameter.
+     * @since 0.2.0 Supports CDN parameter.
      *
      * @param array $options Options must specify a type, a name and a path.
      *              $options = [
@@ -111,7 +111,7 @@ class Asset
      *
      * @param boolean $load (optional) Value to set the parameter to.
      *
-     * @since %%NEXT_VERSION%%
+     * @since 0.2.0
      */
     public static function loadFromCdn($load = null)
     {
@@ -126,7 +126,7 @@ class Asset
      *
      * Useful for loading SVGs or other files inline.
      *
-     * @since %%NEXT_VERSION%%
+     * @since 0.2.0
      *
      * @param string $asset Asset path (relative to the theme directory).
      * @return string|boolean Returns the file contents or false in case of failure.

--- a/lib/Utils/Log.php
+++ b/lib/Utils/Log.php
@@ -102,7 +102,7 @@ class Log
     /**
      * Echoes a variable.
      *
-     * @since %%NEXT_VERSION%%
+     * @since 0.2.0
      *
      * @param mixed    $data     Data to be printed.
      * @param boolean  $postpone Postpone printing to the wp_footer action.


### PR DESCRIPTION
For some reason these weren't replaced during the last release. However, running the release script
again, I saw no issues with it, so in theory it should still work correctly. If it happens again in
the future, I will reinvestigate.