### PR TITLE
fix(SliderMedia): Set slick-dots line-height to 0

### DIFF
--- a/Components/SliderMedia/_slickSliderStyling.styl
+++ b/Components/SliderMedia/_slickSliderStyling.styl
@@ -33,6 +33,7 @@ $slideDotColor = #fff // Color of the dot
   right: 15px
 
 .slick-dots
+  line-height: 0
   list-style: none
   margin: 0
   padding: 0


### PR DESCRIPTION
When `$slideslideDotsOverlay` is turned to `true` and `$slideDotsVerticalPosition` is set to `bottom`, you can actually see that the `.slick-dots` are not placed where you would expect to (22px instead of 15px for default `$slideDotsSize` and $slideDotsOffset`).

This PR adds a `line-height: 0` to `.slick-dots` to make sure that the list will have the same height as the dots. For some reason it won't take a height smaller than `9px`, but that sounds like a very edgy case.