### PR TITLE
build(gulp): import jeet first, variables second

### DIFF
--- a/gulpfile.js/tasks/stylus.js
+++ b/gulpfile.js/tasks/stylus.js
@@ -22,8 +22,8 @@ module.exports = function (config) {
         autoprefixer()
       ],
       import: [
-        path.resolve(__dirname, '../../Components/_variables.styl'),
-        path.resolve(__dirname, '../../node_modules/jeet/styl/index.styl')
+        path.resolve(__dirname, '../../node_modules/jeet/styl/index.styl'),
+        path.resolve(__dirname, '../../Components/_variables.styl')
       ]
     }))
     .on('error', handleErrors)


### PR DESCRIPTION
allows for variables to overwrite jeet defaults, leading to more succinct code throughout the
component code base