### PR TITLE
fix(config/fieldGroups): hide pageComponents on the posts page by default

### DIFF
--- a/config/fieldGroups/pageComponents.json
+++ b/config/fieldGroups/pageComponents.json
@@ -22,6 +22,11 @@
         "param": "post_type",
         "operator": "==",
         "value": "page"
+      },
+      {
+        "param": "page_type",
+        "operator": "!=",
+        "value": "posts_page"
       }
     ]
   ]


### PR DESCRIPTION
since this "page" doesn't really support having ACF fields, it should not be shown here