### PR TITLE
build(gulp): remove linting in default and watch

### DIFF
--- a/gulpfile.js/tasks/default.js
+++ b/gulpfile.js/tasks/default.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
     global.watchMode = true
     runSequence(
       'clean',
-      ['copy', 'stylus', 'lint'],
+      ['copy', 'stylus'],
       ['watch'],
       cb
     )

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -52,9 +52,6 @@ module.exports = function (config) {
     watchAndDelete(config.copy, function () { gulp.start('copy') }, config.dest)
     watchAndDelete(config.watch.stylus, function () { gulp.start('stylus') }, config.dest)
     watch(config.watch.php, function () { })
-    watch(config.lint.stylus, function () { gulp.start('lint:stylus') })
-    watch(config.lint.js, function () { gulp.start('lint:js') })
-    watch(config.lint.php, function () { gulp.start('lint:php') })
     watchWebpack(config.webpack.entry)
   })
   gulp.task('watch', function (cb) {


### PR DESCRIPTION
The linter(s) slow down the default and successive watch tasks tremendously. Linting should be
configured in the IDE and possibly be double-checked with an external build system (Travis, Jenkins,
Buddy, etc.).