### PR TITLE
fix(Features/TimberLoader): use relative file path in renderComponent hook

### DIFF
--- a/Features/TimberLoader/functions.php
+++ b/Features/TimberLoader/functions.php
@@ -15,6 +15,7 @@ add_filter('Flynt/renderComponent', function ($output, $componentName, $componen
     // get index file
     $componentManager = Flynt\ComponentManager::getInstance();
     $filePath = $componentManager->getComponentFilePath($componentName, 'index.twig');
+    $relativeFilePath = ltrim(str_replace(get_template_directory(), '', $filePath), '/');
 
     if (!is_file($filePath)) {
         trigger_error("Template not found: {$filePath}", E_USER_WARNING);
@@ -41,7 +42,7 @@ add_filter('Flynt/renderComponent', function ($output, $componentName, $componen
 
     add_filter('timber/loader/paths', $returnTimberPaths);
 
-    $output = Timber::fetch($filePath, $componentData);
+    $output = Timber::fetch($relativeFilePath, $componentData);
 
     remove_filter('timber/loader/paths', $returnTimberPaths);
 


### PR DESCRIPTION
Related: #263 Props to @bdbch for the initial work on the issue.

resolves #235 
resolves #266 

Alternative solution to the Timber Loader rendering issue. Uses file path relative to the theme directory.

Note: I did not remove the `timber/loader/paths` filter for the component directory in order to have partial twig files still be able to be loaded.

