### PR TITLE
fix(gulpfile.js/config.js): use .test not .dev for local domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Flynt Theme is a ready-to-go WordPress theme that implements all of Flynt's best
 5. Clone the flynt-starter-theme repo to `<your-project>/wp-content/themes`.
 6. Change the host variable in `flynt-starter-theme/gulpfile.js/config.js` to match your host URL.
 ```js
-const host = 'your-host-url.dev'
+const host = 'your-host-url.test'
 ```
 7. In your terminal, navigate to `<your-project>/wp-content/themes/flynt-starter-theme`. Run `yarn` and then `yarn build`.
 8. Go to the administrator back-end of your WordPress site and activate the `flynt-starter-theme` theme.

--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -1,5 +1,5 @@
 const dest = './dist'
-const host = 'flynt.dev'
+const host = 'flynt.test'
 
 module.exports = {
   browserSync: {


### PR DESCRIPTION
Relates to https://github.com/flyntwp/flynt-cli/pull/74