### PR TITLE
fix(yarn): set version constraint for document-register-element to ~1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "conventional-github-releaser": "^1.1.3",
     "csso-loader": "^0.3.0",
     "del": "^3.0.0",
-    "document-register-element": "^1.3.0",
+    "document-register-element": "~1.8.0",
     "draggabilly": "^2.1.1",
     "fancy-log": "^1.3.2",
     "file-loader": "^0.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,9 +1949,11 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-document-register-element@^1.3.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-1.7.0.tgz#d971b62755294b94fcd658b1d8533b0366c852e9"
+document-register-element@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-1.8.1.tgz#db841ece6cba28e6e538ac8e815413b59e86047e"
+  dependencies:
+    lightercollective "^0.0.0"
 
 domain-browser@^1.1.1:
   version "1.1.7"
@@ -3852,6 +3854,10 @@ liftoff@^2.1.0:
     lodash.mapvalues "^4.4.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
+
+lightercollective@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/lightercollective/-/lightercollective-0.0.0.tgz#5b85f6755b78c1f94db590e479f954cbfeeb0409"
 
 limiter@^1.0.5:
   version "1.1.3"


### PR DESCRIPTION
Higher versions are not currently compatible with Flynt.