### PR TITLE
build(gulpfile.js): fix reloading of PHP files outside the copy scope

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -49,7 +49,10 @@ module.exports = {
   ],
   watch: {
     stylus: './{Components,Features}/**/*.styl',
-    php: './**/*.php',
+    php: [
+      './**/*.php',
+      '!./{Components,Features}/**/*.php'
+    ],
     hardReloadOnStylFiles: ['Components/_variables.styl'],
     stylusPartials: {
       partialCssFilenamePrefix: '_',

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -96,6 +96,7 @@ function checkForCssVariablesStyl (file, config) {
 
 module.exports = function (config) {
   gulp.task('watch:files', function () {
+    const browserSync = require('browser-sync')
     globby = require('globby')
     touch = require('touch')
     watch = require('gulp-watch')
@@ -105,7 +106,7 @@ module.exports = function (config) {
       checkForCssVariablesStyl(file, config)
       gulp.start('stylus')
     }, config.dest)
-    watch(config.watch.php, function () { })
+    watch(config.watch.php, function () { browserSync.reload() })
     watchWebpack(config.webpack.entry)
   })
   gulp.task('watch', function (cb) {


### PR DESCRIPTION
This can lead to double reloading of PHP files also being watched through copy, but I'm not sure how else to do it and it doesn't seem to have a visible impact.